### PR TITLE
add a conditional field expression

### DIFF
--- a/react/BuyboxApp.tsx
+++ b/react/BuyboxApp.tsx
@@ -6,22 +6,23 @@ import BuyboxProvider from './provider/BuyboxProvider'
 import type { Strategies, TriggerCepChangeEventType } from './typings/types'
 
 interface Props {
-  sortStrategy?: Strategies
+  conditionalStrategy?: {
+    sortStrategy?: Strategies
+    expression: string
+  }
   triggerCepChangeEvent?: TriggerCepChangeEventType
-  expression: string
 }
 
 const BuyboxApp: StorefrontFunctionComponent<Props> = ({
   children,
-  sortStrategy,
-  expression,
+  conditionalStrategy,
   triggerCepChangeEvent = 'orderForm',
 }) => {
-  return sortStrategy ? (
+  return conditionalStrategy?.sortStrategy ? (
     <BuyboxProvider
-      sortStrategy={sortStrategy}
+      sortStrategy={conditionalStrategy.sortStrategy}
       triggerCepChangeEvent={triggerCepChangeEvent}
-      expression={expression}
+      expression={conditionalStrategy.expression}
     >
       <ProductWithSortedSellers>{children}</ProductWithSortedSellers>
     </BuyboxProvider>
@@ -58,21 +59,39 @@ BuyboxApp.schema = {
   title: messages.title.id,
   type: 'object',
   properties: {
-    sortStrategy: {
-      type: 'string',
-      title: messages.sortStrategyTitle.id,
-      description: messages.sortStrategyDescription.id,
-      enum: ['price', 'priceShipping', 'customExpression'],
-      enumNames: [
-        'admin/editor.buybox-context.price.label',
-        'admin/editor.buybox-context.price-and-shipping.label',
-        'admin/editor.buybox-context.custom-expression',
-      ],
-    },
-    expression: {
-      type: 'string',
-      title: messages.expressionTitle.id,
-      description: messages.expressionDescription.id,
+    conditionalStrategy: {
+      type: 'object',
+      properties: {
+        sortStrategy: {
+          type: 'string',
+          title: messages.sortStrategyTitle.id,
+          description: messages.sortStrategyDescription.id,
+          enum: ['price', 'priceShipping', 'customExpression'],
+          enumNames: [
+            'admin/editor.buybox-context.price.label',
+            'admin/editor.buybox-context.price-and-shipping.label',
+            'admin/editor.buybox-context.custom-expression',
+          ],
+        },
+      },
+      dependencies: {
+        sortStrategy: {
+          oneOf: [
+            {
+              properties: {
+                sortStrategy: {
+                  enum: ['customExpression'],
+                },
+                expression: {
+                  type: 'string',
+                  title: messages.expressionTitle.id,
+                  description: messages.expressionDescription.id,
+                },
+              },
+            },
+          ],
+        },
+      },
     },
     triggerCepChangeEvent: {
       type: 'string',


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

Created a conditional to shows **Expression** field only when the **Sort Strategy** is selected with **Custom Expression** option.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://wagnerlduarte--pedrocruzio.myvtex.com/admin/cms/site-editor/sellers/luxury-purple-ballon?skuId=33)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

![conditional](https://user-images.githubusercontent.com/17439470/134415184-95e9aa49-55ac-4083-a334-ed2c704f0d3b.gif)


#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/n0tQZejx4Rh28/giphy.gif)
