### PR TITLE
add productSpotPrice and productAvailableQuantity variables

### DIFF
--- a/messages/context.json
+++ b/messages/context.json
@@ -10,5 +10,5 @@
   "admin/editor.buybox-context.order-form.label": "Order Form",
   "admin/editor.buybox-context.seller-selector.label": "Seller Selector",
   "admin/editor.buybox-context.expression-title": "Expression",
-  "admin/editor.buybox-context.expression-description": "Configure expressions to sort sellers: productPrice, shippingPrice"
+  "admin/editor.buybox-context.expression-description": "Configure expressions to sort sellers: productPrice, productSpotPrice, productAvailableQuantity, shippingPrice"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -10,5 +10,5 @@
   "admin/editor.buybox-context.order-form.label": "Order Form",
   "admin/editor.buybox-context.seller-selector.label": "Seller Selector",
   "admin/editor.buybox-context.expression-title": "Expression",
-  "admin/editor.buybox-context.expression-description": "Configure expressions to sort sellers: productPrice, shippingPrice"
+  "admin/editor.buybox-context.expression-description": "Configure expressions to sort sellers: productPrice, productSpotPrice, productAvailableQuantity, shippingPrice"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -10,5 +10,5 @@
   "admin/editor.buybox-context.order-form.label": "Order Form",
   "admin/editor.buybox-context.seller-selector.label": "Seller Selector",
   "admin/editor.buybox-context.expression-title": "Expressão",
-  "admin/editor.buybox-context.expression-description": "Configure expressões para ordenar os vendedores: productPrice, shippingPrice"
+  "admin/editor.buybox-context.expression-description": "Configure expressões para ordenar os vendedores: productPrice, productSpotPrice, productAvailableQuantity, shippingPrice"
 }

--- a/react/__mocks__/productContext.ts
+++ b/react/__mocks__/productContext.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   ItemMetadata,
   ProductContextState,
 } from 'vtex.product-context/react/ProductTypes'

--- a/react/__mocks__/sellers.ts
+++ b/react/__mocks__/sellers.ts
@@ -1,4 +1,4 @@
-import { LogisticsInfo, SellerLogisticsInfoResult } from '../typings/types'
+import type { LogisticsInfo, SellerLogisticsInfoResult } from '../typings/types'
 
 const unsortedSellersMock = [
   {

--- a/react/__tests__/utils/sortSellers.test.ts
+++ b/react/__tests__/utils/sortSellers.test.ts
@@ -160,7 +160,7 @@ describe('sortSellersByPriceShipping', () => {
 })
 
 describe('sortSellersByCustomExpression', () => {
-  it('should sort sellers correctly', () => {
+  it('should sort sellers correctly with expression productPrice + shippingPrice', () => {
     // arrange
     const expression = 'productPrice + shippingPrice'
 
@@ -174,6 +174,64 @@ describe('sortSellersByCustomExpression', () => {
       seller1,
       seller3,
       seller4,
+    ]
+
+    const unsortedSellers: SellerLogisticsInfoResult[] =
+      unsortedSellersShippingMock
+
+    // act
+    const sortedSellers = sortSellersByCustomExpression(
+      unsortedSellers,
+      expression
+    )
+
+    // assert
+    expect(sortedSellers).toStrictEqual(expected)
+  })
+
+  it('should sort sellers correctly with expression productSpotPrice + shippingPrice', () => {
+    // arrange
+    const expression = 'productSpotPrice + shippingPrice'
+
+    const [seller1, seller2, seller3, seller4, seller5, seller6] =
+      unsortedSellersShippingMock
+
+    const expected: SellerLogisticsInfoResult[] = [
+      seller5,
+      seller6,
+      seller2,
+      seller1,
+      seller3,
+      seller4,
+    ]
+
+    const unsortedSellers: SellerLogisticsInfoResult[] =
+      unsortedSellersShippingMock
+
+    // act
+    const sortedSellers = sortSellersByCustomExpression(
+      unsortedSellers,
+      expression
+    )
+
+    // assert
+    expect(sortedSellers).toStrictEqual(expected)
+  })
+
+  it('should sort sellers correctly with expression productAvailableQuantity < 1000', () => {
+    // arrange
+    const expression = 'productAvailableQuantity < 1000'
+
+    const [seller1, seller2, seller3, seller4, seller5, seller6] =
+      unsortedSellersShippingMock
+
+    const expected: SellerLogisticsInfoResult[] = [
+      seller1,
+      seller3,
+      seller5,
+      seller2,
+      seller4,
+      seller6,
     ]
 
     const unsortedSellers: SellerLogisticsInfoResult[] =
@@ -268,5 +326,26 @@ describe('sortSellersByCustomExpression', () => {
 
     // assert
     expect(sortedSellers).toStrictEqual(expected)
+  })
+
+  it('should return a same array unsorted when expression is wrong', () => {
+    // arrange
+    const expression = 'wrongWord1 + wrongWord2'
+
+    jest.spyOn(console, 'error').mockImplementation()
+
+    const expected: SellerLogisticsInfoResult[] = unsortedSellersShippingMock
+    const unsortedSellers: SellerLogisticsInfoResult[] =
+      unsortedSellersShippingMock
+
+    // act
+    const sortedSellers = sortSellersByCustomExpression(
+      unsortedSellers,
+      expression
+    )
+
+    // assert
+    expect(sortedSellers).toStrictEqual(expected)
+    expect(console.error).toBeCalledTimes(1)
   })
 })


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->
Added `productSpotPrice` and `productAvailableQuantity` variables to calculate math expression to sort sellers.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://wagnerlduarte--pedrocruzio.myvtex.com/admin/cms/site-editor/sellers/luxury-purple-ballon?skuId=33)

On expression field put a value like: `productSpotPrice / productAvailableQuantity`

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/1evtSTqDXv7tqu7cL4/giphy.gif?cid=790b7611a642236c80ca6a6016508f8230297034f81bc432&rid=giphy.gif&ct=g)
