### PR TITLE
ignore sellers protocol that don't exists on context

### DIFF
--- a/react/__tests__/hooks/useSellersByProtocol.test.ts
+++ b/react/__tests__/hooks/useSellersByProtocol.test.ts
@@ -106,4 +106,36 @@ describe('useSellersByProtocol', () => {
     // assert
     expect(sellersInfoResult).toStrictEqual([])
   })
+
+  it('should return an array without sellers that do not exists on sellerLogisticsInfo', async () => {
+    // arrange
+    jest
+      .spyOn(reactapollo, 'useQuery')
+      .mockImplementation()
+      .mockReturnValue({
+        data: {
+          sortSellers: {
+            sellers: ['10', '20', '3', '1', '4', '2', '5'],
+          },
+        },
+      } as any)
+
+    const sellerLogisticsInfo: SellerLogisticsInfoResult[] = unsortedSellersMock
+
+    const [seller1, seller2, seller3, seller4, seller5] = unsortedSellersMock
+
+    // act
+    const {
+      result: { current: sellersInfoResult },
+    } = renderHook(() => useSellersByProtocol(sellerLogisticsInfo))
+
+    // assert
+    expect(sellersInfoResult).toStrictEqual([
+      seller3,
+      seller1,
+      seller4,
+      seller2,
+      seller5,
+    ])
+  })
 })

--- a/react/hooks/useSellersByProtocol.ts
+++ b/react/hooks/useSellersByProtocol.ts
@@ -60,5 +60,11 @@ export const useSellersByProtocol = (
     }
   )
 
-  return data.sortSellers.sellers.map((sellerId) => sellersInfoIndex[sellerId])
+  return data.sortSellers.sellers.reduce((acummulator, sellerId) => {
+    if (sellersInfoIndex[sellerId]) {
+      acummulator.push(sellersInfoIndex[sellerId])
+    }
+
+    return acummulator
+  }, [] as SellerLogisticsInfoResult[])
 }


### PR DESCRIPTION
#### What problem is this solving?

When the sort strategy by protocol is used, the return may have values that don't exists on seller list of context. Because of this, it's necessary to remove this inexistent sellers to works fine.


#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/HyCxJErg9jTCU/giphy.gif)
