### PR TITLE
fix when logistcsInfo is undefined

### DIFF
--- a/react/__mocks__/sellers.ts
+++ b/react/__mocks__/sellers.ts
@@ -267,10 +267,6 @@ const unsortedSellersShippingMock = [
         Installments: [],
       },
     },
-    logisticsInfo: {
-      itemIndex: 1,
-      slas: [],
-    } as LogisticsInfo,
   },
   {
     seller: {

--- a/react/utils/sortSellers.ts
+++ b/react/utils/sortSellers.ts
@@ -31,11 +31,11 @@ export const sortSellersByPriceShipping = (
   const sortedList = [...sellersInfo]
 
   sortedList.sort((sellerA, sellerB) => {
-    if (sellerA.logisticsInfo?.slas?.length === 0) {
+    if (!sellerA.logisticsInfo?.slas?.length) {
       return 1
     }
 
-    if (sellerB.logisticsInfo?.slas?.length === 0) {
+    if (!sellerB.logisticsInfo?.slas?.length) {
       return -1
     }
 
@@ -162,11 +162,11 @@ export const sortSellersByCustomExpression = (
     sortedList.sort((sellerA, sellerB) => {
       // set the sellers without SLA calculated to end of the array
       if (logisticInfoVariables.some((info) => expression.includes(info))) {
-        if (sellerA.logisticsInfo?.slas?.length === 0) {
+        if (!sellerA.logisticsInfo?.slas?.length) {
           return 1
         }
 
-        if (sellerB.logisticsInfo?.slas?.length === 0) {
+        if (!sellerB.logisticsInfo?.slas?.length) {
           return -1
         }
       }


### PR DESCRIPTION
#### What problem is this solving?
Sometimes the `logisticsInfo` return `undefined`. In this case, the behavior can be the same when `sla` list count is zero.
With this fix, the problem is solved, because now just check is `falsy` to enter on if condition.

<!--- What is the motivation and context for this change? -->


#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/3o7WIwXnnOzDUgzL0s/giphy.gif)
