### PR TITLE
match seller and logistic info by itemIndex property

### DIFF
--- a/react/__tests__/hooks/useSellerLoginstcsInfoSellerSelector.test.ts
+++ b/react/__tests__/hooks/useSellerLoginstcsInfoSellerSelector.test.ts
@@ -14,9 +14,9 @@ describe('useSellerLoginstcsInfoSellerSelector', () => {
       sellerList: null,
       shippingQuotes: {
         logisticsInfo: [
-          { itemIndex: 1, slas: [] },
+          { itemIndex: 0, slas: [] },
           {
-            itemIndex: 2,
+            itemIndex: 1,
             slas: [
               {
                 id: '1',

--- a/react/hooks/useSellerLoginstcsInfoSellerSelector.ts
+++ b/react/hooks/useSellerLoginstcsInfoSellerSelector.ts
@@ -3,7 +3,7 @@ import { useProduct } from 'vtex.product-context'
 import { SellerContext } from 'vtex.seller-selector'
 
 import type { LogisticsInfo, SellerLogisticsInfoResult } from '../typings/types'
-import { isAvailableSellers } from '../utils'
+import { isAvailableSeller } from '../utils'
 
 export const useSellerLoginstcsInfoSellerSelector =
   (): SellerLogisticsInfoResult[] => {
@@ -21,16 +21,16 @@ export const useSellerLoginstcsInfoSellerSelector =
       [shippingQuotes?.logisticsInfo]
     )
 
-    const sellersLogisticsInfo = selectedItem
-      ? selectedItem.sellers.map((seller, index) => {
-          return {
-            seller,
-            logisticsInfo: logisticsInfo ? logisticsInfo[index] : undefined,
+    return selectedItem
+      ? selectedItem.sellers.reduce((accumulator, seller, index) => {
+          if (isAvailableSeller(seller)) {
+            accumulator.push({
+              seller,
+              logisticsInfo: logisticsInfo ? logisticsInfo[index] : undefined,
+            })
           }
-        })
-      : []
 
-    return sellersLogisticsInfo.filter((sellerLogisticsInfo) =>
-      isAvailableSellers(sellerLogisticsInfo.seller)
-    )
+          return accumulator
+        }, [] as SellerLogisticsInfoResult[])
+      : []
   }

--- a/react/hooks/useSellerLoginstcsInfoSellerSelector.ts
+++ b/react/hooks/useSellerLoginstcsInfoSellerSelector.ts
@@ -2,8 +2,8 @@ import { useMemo } from 'react'
 import { useProduct } from 'vtex.product-context'
 import { SellerContext } from 'vtex.seller-selector'
 
-import type { SellerLogisticsInfoResult } from '../typings/types'
-import { getAvailableSellers } from '../utils'
+import type { LogisticsInfo, SellerLogisticsInfoResult } from '../typings/types'
+import { isAvailableSellers } from '../utils'
 
 export const useSellerLoginstcsInfoSellerSelector =
   (): SellerLogisticsInfoResult[] => {
@@ -12,14 +12,25 @@ export const useSellerLoginstcsInfoSellerSelector =
     const { shippingQuotes } = SellerContext.useSellerContext()
 
     const logisticsInfo = useMemo(
-      () => shippingQuotes?.logisticsInfo,
+      () =>
+        shippingQuotes?.logisticsInfo.reduce((acummulator, currentValue) => {
+          acummulator[currentValue.itemIndex] = currentValue
+
+          return acummulator
+        }, {} as { [key in string]: LogisticsInfo }),
       [shippingQuotes?.logisticsInfo]
     )
 
-    return getAvailableSellers(selectedItem?.sellers).map((seller, index) => {
-      return {
-        seller,
-        logisticsInfo: logisticsInfo ? logisticsInfo[index] : undefined,
-      }
-    })
+    const sellersLogisticsInfo = selectedItem
+      ? selectedItem.sellers.map((seller, index) => {
+          return {
+            seller,
+            logisticsInfo: logisticsInfo ? logisticsInfo[index] : undefined,
+          }
+        })
+      : []
+
+    return sellersLogisticsInfo.filter((sellerLogisticsInfo) =>
+      isAvailableSellers(sellerLogisticsInfo.seller)
+    )
   }

--- a/react/hooks/useSellerLogisticsInfo.ts
+++ b/react/hooks/useSellerLogisticsInfo.ts
@@ -6,7 +6,7 @@ import { OrderForm } from 'vtex.order-manager'
 import { useProduct } from 'vtex.product-context'
 
 import SimulateShippingQuery from '../graphql/SimulateShipping.gql'
-import type { SellerLogisticsInfoResult } from '../typings/types'
+import type { LogisticsInfo, SellerLogisticsInfoResult } from '../typings/types'
 import { getAvailableSellers } from '../utils'
 
 export const useSellerLogisticsInfo = (): SellerLogisticsInfoResult[] => {
@@ -51,7 +51,15 @@ export const useSellerLogisticsInfo = (): SellerLogisticsInfoResult[] => {
   ])
 
   const logisticsInfo = useMemo(
-    () => shippingData?.shipping.logisticsInfo,
+    () =>
+      shippingData?.shipping.logisticsInfo?.reduce(
+        (acummulator, currentValue) => {
+          acummulator[currentValue.itemIndex] = currentValue
+
+          return acummulator
+        },
+        {} as { [key in string]: LogisticsInfo }
+      ),
     [shippingData?.shipping.logisticsInfo]
   )
 

--- a/react/utils/index.ts
+++ b/react/utils/index.ts
@@ -1,11 +1,11 @@
 import type { Seller } from '../typings/types'
 
-export const isAvailableSellers = (seller: Seller) => {
+export const isAvailableSeller = (seller: Seller) => {
   return seller.commertialOffer.AvailableQuantity > 0
 }
 
 export const getAvailableSellers = (sellers: Seller[] | undefined) => {
   if (!sellers) return []
 
-  return sellers.filter(isAvailableSellers)
+  return sellers.filter(isAvailableSeller)
 }

--- a/react/utils/index.ts
+++ b/react/utils/index.ts
@@ -1,9 +1,11 @@
 import type { Seller } from '../typings/types'
 
+export const isAvailableSellers = (seller: Seller) => {
+  return seller.commertialOffer.AvailableQuantity > 0
+}
+
 export const getAvailableSellers = (sellers: Seller[] | undefined) => {
   if (!sellers) return []
 
-  return sellers.filter(
-    (seller) => seller.commertialOffer.AvailableQuantity > 0
-  )
+  return sellers.filter(isAvailableSellers)
 }


### PR DESCRIPTION
#### What problem is this solving?

When is calculate `logisticsInfo`, this object have a property `itemIndex` to indicate which seller link with this object. Before that I link `seller` with `logisticsInfo` by array index, but this is wrong. I need link these two objects based on `itemIndex` to be correct.

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/uHQwBUOp4QVtm/giphy.gif)
