### PR TITLE
fix minPrice sort when SLA price is free

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- minPrice sort when SLA price is free (0.00)
+
 ## [1.0.1] - 2022-07-20
 
 ## [1.0.0] - 2022-07-14

--- a/react/__mocks__/sellers.ts
+++ b/react/__mocks__/sellers.ts
@@ -354,4 +354,431 @@ const unsortedSellersShippingMock = [
   },
 ] as SellerLogisticsInfoResult[]
 
-export { unsortedSellersMock, unsortedSellersShippingMock }
+const unsortedSellerLogisticsInfoMock = [
+  {
+    seller: {
+      sellerId: 'rjriodejaneirocasashopping099',
+      sellerName: 'Loja IWS - Casa Shopping (RJ)',
+      sellerDefault: true,
+      addToCartLink:
+        'https://portal.vtexcommercestable.com.br/checkout/cart/add?sku=240&qty=1&seller=rjriodejaneirocasashopping099&sc=1&price=8990&cv=E856A167161640718AB90DD345A81A7E_&sc=1',
+      commertialOffer: {
+        discountHighlights: [],
+        teasers: [],
+        Price: 89.9,
+        ListPrice: 89.9,
+        Tax: 0,
+        taxPercentage: 0,
+        spotPrice: 89.9,
+        PriceWithoutDiscount: 89.9,
+        RewardValue: 0,
+        PriceValidUntil: '2023-07-29T13:35:37Z',
+        AvailableQuantity: 2,
+        CacheVersionUsedToCallCheckout: 'E856A167161640718AB90DD345A81A7E_',
+        Installments: [],
+      },
+    },
+    logisticsInfo: {
+      itemIndex: 0,
+      slas: [
+        {
+          id: 'PAC',
+          name: 'PAC',
+          price: 0,
+          shippingEstimate: '6bd',
+          shippingEstimateDate: '',
+        },
+        {
+          id: 'SEDEX',
+          name: 'SEDEX',
+          price: 3188,
+          shippingEstimate: '2bd',
+          shippingEstimateDate: '',
+        },
+      ],
+    },
+  },
+  {
+    seller: {
+      sellerId: 'lojaiwslourdesbh573',
+      sellerName: 'Loja IWS - Lourdes (BH)',
+      sellerDefault: false,
+      addToCartLink:
+        'https://portal.vtexcommercestable.com.br/checkout/cart/add?sku=240&qty=1&seller=lojaiwslourdesbh573&sc=1&price=8990&cv=E856A167161640718AB90DD345A81A7E_&sc=1',
+      commertialOffer: {
+        discountHighlights: [],
+        teasers: [],
+        Price: 89.9,
+        ListPrice: 89.9,
+        Tax: 0,
+        taxPercentage: 0,
+        spotPrice: 89.9,
+        PriceWithoutDiscount: 89.9,
+        RewardValue: 0,
+        PriceValidUntil: '2023-07-29T13:35:37Z',
+        AvailableQuantity: 3,
+        CacheVersionUsedToCallCheckout: 'E856A167161640718AB90DD345A81A7E_',
+        Installments: [],
+      },
+    },
+    logisticsInfo: {
+      itemIndex: 1,
+      slas: [
+        {
+          id: 'Correios - PAC',
+          name: 'Correios - PAC',
+          price: 0,
+          shippingEstimate: '6bd',
+          shippingEstimateDate: '',
+        },
+        {
+          id: 'Correios - SEDEX',
+          name: 'Correios - SEDEX',
+          price: 3180,
+          shippingEstimate: '2bd',
+          shippingEstimateDate: '',
+        },
+      ],
+    },
+  },
+  {
+    seller: {
+      sellerId: 'lojaiwscampinassp719',
+      sellerName: 'Loja IWS - Campinas (SP)',
+      sellerDefault: false,
+      addToCartLink:
+        'https://portal.vtexcommercestable.com.br/checkout/cart/add?sku=240&qty=1&seller=lojaiwscampinassp719&sc=1&price=8990&cv=E856A167161640718AB90DD345A81A7E_&sc=1',
+      commertialOffer: {
+        discountHighlights: [],
+        teasers: [],
+        Price: 89.9,
+        ListPrice: 89.9,
+        Tax: 0,
+        taxPercentage: 0,
+        spotPrice: 89.9,
+        PriceWithoutDiscount: 89.9,
+        RewardValue: 0,
+        PriceValidUntil: '2023-07-29T13:35:37Z',
+        AvailableQuantity: 4,
+        CacheVersionUsedToCallCheckout: 'E856A167161640718AB90DD345A81A7E_',
+        Installments: [],
+      },
+    },
+    logisticsInfo: {
+      itemIndex: 2,
+      slas: [
+        {
+          id: 'Correios - SEDEX',
+          name: 'Correios - SEDEX',
+          price: 0,
+          shippingEstimate: '2bd',
+          shippingEstimateDate: '',
+        },
+      ],
+    },
+  },
+  {
+    seller: {
+      sellerId: 'lojaiwssilvianobrandaobh935',
+      sellerName: 'Loja IWS - Silviano Brandão (BH)',
+      sellerDefault: false,
+      addToCartLink:
+        'https://portal.vtexcommercestable.com.br/checkout/cart/add?sku=240&qty=1&seller=lojaiwssilvianobrandaobh935&sc=1&price=8990&cv=E856A167161640718AB90DD345A81A7E_&sc=1',
+      commertialOffer: {
+        discountHighlights: [],
+        teasers: [],
+        Price: 89.9,
+        ListPrice: 89.9,
+        Tax: 0,
+        taxPercentage: 0,
+        spotPrice: 89.9,
+        PriceWithoutDiscount: 89.9,
+        RewardValue: 0,
+        PriceValidUntil: '2023-07-29T13:35:37Z',
+        AvailableQuantity: 5,
+        CacheVersionUsedToCallCheckout: 'E856A167161640718AB90DD345A81A7E_',
+        Installments: [],
+      },
+    },
+    logisticsInfo: {
+      itemIndex: 3,
+      slas: [
+        {
+          id: 'Correios - PAC',
+          name: 'Correios - PAC',
+          price: 0,
+          shippingEstimate: '6bd',
+          shippingEstimateDate: '',
+        },
+        {
+          id: 'Correios - SEDEX',
+          name: 'Correios - SEDEX',
+          price: 3180,
+          shippingEstimate: '2bd',
+          shippingEstimateDate: '',
+        },
+      ],
+    },
+  },
+  {
+    seller: {
+      sellerId: 'lojaiwscampograndems217',
+      sellerName: 'Loja IWS - Campo Grande (MS)',
+      sellerDefault: false,
+      addToCartLink:
+        'https://portal.vtexcommercestable.com.br/checkout/cart/add?sku=240&qty=1&seller=lojaiwscampograndems217&sc=1&price=8990&cv=E856A167161640718AB90DD345A81A7E_&sc=1',
+      commertialOffer: {
+        discountHighlights: [],
+        teasers: [],
+        Price: 89.9,
+        ListPrice: 89.9,
+        Tax: 0,
+        taxPercentage: 0,
+        spotPrice: 89.9,
+        PriceWithoutDiscount: 89.9,
+        RewardValue: 0,
+        PriceValidUntil: '2023-07-29T13:35:37Z',
+        AvailableQuantity: 1,
+        CacheVersionUsedToCallCheckout: 'E856A167161640718AB90DD345A81A7E_',
+        Installments: [],
+      },
+    },
+    logisticsInfo: {
+      itemIndex: 4,
+      slas: [
+        {
+          id: 'Correios - PAC',
+          name: 'Correios - PAC',
+          price: 0,
+          shippingEstimate: '7bd',
+          shippingEstimateDate: '',
+        },
+        {
+          id: 'Correios - SEDEX',
+          name: 'Correios - SEDEX',
+          price: 4416,
+          shippingEstimate: '2bd',
+          shippingEstimateDate: '',
+        },
+      ],
+    },
+  },
+] as SellerLogisticsInfoResult[]
+
+const sortedSellerLogisticsInfoMock = [
+  {
+    seller: {
+      sellerId: 'lojaiwscampinassp719',
+      sellerName: 'Loja IWS - Campinas (SP)',
+      sellerDefault: true,
+      addToCartLink:
+        'https://portal.vtexcommercestable.com.br/checkout/cart/add?sku=240&qty=1&seller=lojaiwscampinassp719&sc=1&price=8990&cv=E856A167161640718AB90DD345A81A7E_&sc=1',
+      commertialOffer: {
+        discountHighlights: [],
+        teasers: [],
+        Price: 89.9,
+        ListPrice: 89.9,
+        Tax: 0,
+        taxPercentage: 0,
+        spotPrice: 89.9,
+        PriceWithoutDiscount: 89.9,
+        RewardValue: 0,
+        PriceValidUntil: '2023-07-29T13:35:37Z',
+        AvailableQuantity: 4,
+        CacheVersionUsedToCallCheckout: 'E856A167161640718AB90DD345A81A7E_',
+        Installments: [],
+      },
+    },
+    logisticsInfo: {
+      itemIndex: 2,
+      slas: [
+        {
+          id: 'Correios - SEDEX',
+          name: 'Correios - SEDEX',
+          price: 0,
+          shippingEstimate: '2bd',
+          shippingEstimateDate: '',
+        },
+      ],
+    },
+  },
+  {
+    seller: {
+      sellerId: 'lojaiwslourdesbh573',
+      sellerName: 'Loja IWS - Lourdes (BH)',
+      sellerDefault: false,
+      addToCartLink:
+        'https://portal.vtexcommercestable.com.br/checkout/cart/add?sku=240&qty=1&seller=lojaiwslourdesbh573&sc=1&price=8990&cv=E856A167161640718AB90DD345A81A7E_&sc=1',
+      commertialOffer: {
+        discountHighlights: [],
+        teasers: [],
+        Price: 89.9,
+        ListPrice: 89.9,
+        Tax: 0,
+        taxPercentage: 0,
+        spotPrice: 89.9,
+        PriceWithoutDiscount: 89.9,
+        RewardValue: 0,
+        PriceValidUntil: '2023-07-29T13:35:37Z',
+        AvailableQuantity: 3,
+        CacheVersionUsedToCallCheckout: 'E856A167161640718AB90DD345A81A7E_',
+        Installments: [],
+      },
+    },
+    logisticsInfo: {
+      itemIndex: 1,
+      slas: [
+        {
+          id: 'Correios - SEDEX',
+          name: 'Correios - SEDEX',
+          price: 3180,
+          shippingEstimate: '2bd',
+          shippingEstimateDate: '',
+        },
+        {
+          id: 'Correios - PAC',
+          name: 'Correios - PAC',
+          price: 0,
+          shippingEstimate: '6bd',
+          shippingEstimateDate: '',
+        },
+      ],
+    },
+  },
+  {
+    seller: {
+      sellerId: 'lojaiwssilvianobrandaobh935',
+      sellerName: 'Loja IWS - Silviano Brandão (BH)',
+      sellerDefault: false,
+      addToCartLink:
+        'https://portal.vtexcommercestable.com.br/checkout/cart/add?sku=240&qty=1&seller=lojaiwssilvianobrandaobh935&sc=1&price=8990&cv=E856A167161640718AB90DD345A81A7E_&sc=1',
+      commertialOffer: {
+        discountHighlights: [],
+        teasers: [],
+        Price: 89.9,
+        ListPrice: 89.9,
+        Tax: 0,
+        taxPercentage: 0,
+        spotPrice: 89.9,
+        PriceWithoutDiscount: 89.9,
+        RewardValue: 0,
+        PriceValidUntil: '2023-07-29T13:35:37Z',
+        AvailableQuantity: 5,
+        CacheVersionUsedToCallCheckout: 'E856A167161640718AB90DD345A81A7E_',
+        Installments: [],
+      },
+    },
+    logisticsInfo: {
+      itemIndex: 3,
+      slas: [
+        {
+          id: 'Correios - SEDEX',
+          name: 'Correios - SEDEX',
+          price: 3180,
+          shippingEstimate: '2bd',
+          shippingEstimateDate: '',
+        },
+        {
+          id: 'Correios - PAC',
+          name: 'Correios - PAC',
+          price: 0,
+          shippingEstimate: '6bd',
+          shippingEstimateDate: '',
+        },
+      ],
+    },
+  },
+  {
+    seller: {
+      sellerId: 'rjriodejaneirocasashopping099',
+      sellerName: 'Loja IWS - Casa Shopping (RJ)',
+      sellerDefault: false,
+      addToCartLink:
+        'https://portal.vtexcommercestable.com.br/checkout/cart/add?sku=240&qty=1&seller=rjriodejaneirocasashopping099&sc=1&price=8990&cv=E856A167161640718AB90DD345A81A7E_&sc=1',
+      commertialOffer: {
+        discountHighlights: [],
+        teasers: [],
+        Price: 89.9,
+        ListPrice: 89.9,
+        Tax: 0,
+        taxPercentage: 0,
+        spotPrice: 89.9,
+        PriceWithoutDiscount: 89.9,
+        RewardValue: 0,
+        PriceValidUntil: '2023-07-29T13:35:37Z',
+        AvailableQuantity: 2,
+        CacheVersionUsedToCallCheckout: 'E856A167161640718AB90DD345A81A7E_',
+        Installments: [],
+      },
+    },
+    logisticsInfo: {
+      itemIndex: 0,
+      slas: [
+        {
+          id: 'SEDEX',
+          name: 'SEDEX',
+          price: 3188,
+          shippingEstimate: '2bd',
+          shippingEstimateDate: '',
+        },
+        {
+          id: 'PAC',
+          name: 'PAC',
+          price: 0,
+          shippingEstimate: '6bd',
+          shippingEstimateDate: '',
+        },
+      ],
+    },
+  },
+  {
+    seller: {
+      sellerId: 'lojaiwscampograndems217',
+      sellerName: 'Loja IWS - Campo Grande (MS)',
+      sellerDefault: false,
+      addToCartLink:
+        'https://portal.vtexcommercestable.com.br/checkout/cart/add?sku=240&qty=1&seller=lojaiwscampograndems217&sc=1&price=8990&cv=E856A167161640718AB90DD345A81A7E_&sc=1',
+      commertialOffer: {
+        discountHighlights: [],
+        teasers: [],
+        Price: 89.9,
+        ListPrice: 89.9,
+        Tax: 0,
+        taxPercentage: 0,
+        spotPrice: 89.9,
+        PriceWithoutDiscount: 89.9,
+        RewardValue: 0,
+        PriceValidUntil: '2023-07-29T13:35:37Z',
+        AvailableQuantity: 1,
+        CacheVersionUsedToCallCheckout: 'E856A167161640718AB90DD345A81A7E_',
+        Installments: [],
+      },
+    },
+    logisticsInfo: {
+      itemIndex: 4,
+      slas: [
+        {
+          id: 'Correios - SEDEX',
+          name: 'Correios - SEDEX',
+          price: 4416,
+          shippingEstimate: '2bd',
+          shippingEstimateDate: '',
+        },
+        {
+          id: 'Correios - PAC',
+          name: 'Correios - PAC',
+          price: 0,
+          shippingEstimate: '7bd',
+          shippingEstimateDate: '',
+        },
+      ],
+    },
+  },
+] as SellerLogisticsInfoResult[]
+
+export {
+  unsortedSellersMock,
+  unsortedSellersShippingMock,
+  unsortedSellerLogisticsInfoMock,
+  sortedSellerLogisticsInfoMock,
+}

--- a/react/__tests__/utils/sortSellers.test.ts
+++ b/react/__tests__/utils/sortSellers.test.ts
@@ -8,6 +8,8 @@ import {
 import {
   unsortedSellersMock,
   unsortedSellersShippingMock,
+  sortedSellerLogisticsInfoMock,
+  unsortedSellerLogisticsInfoMock,
 } from '../../__mocks__/sellers'
 
 describe('sortSellersByPrice', () => {
@@ -434,5 +436,31 @@ describe('sortSellersByCustomExpression', () => {
     // assert
     expect(sortedSellers).toStrictEqual(expected)
     expect(console.error).toBeCalledTimes(1)
+  })
+
+  it('should sort by SLA correctly when the price is of SLA is 0.00 and shipping estimate is bigger', () => {
+    // arrange
+    const expression = 'minShippingEstimate * 100000 + maxShippingPrice'
+
+    // act
+    const sortedSellers = sortSellersByCustomExpression(
+      unsortedSellerLogisticsInfoMock,
+      expression
+    )
+
+    // assert
+    const SLAs = sortedSellers
+      .filter((seller) => seller.logisticsInfo?.slas.length)
+      .map((sla, index) => {
+        return {
+          ...sla,
+          seller: {
+            ...sla.seller,
+            sellerDefault: index === 0,
+          },
+        }
+      })
+
+    expect(SLAs).toEqual(sortedSellerLogisticsInfoMock)
   })
 })

--- a/react/utils/sortSellers.ts
+++ b/react/utils/sortSellers.ts
@@ -99,11 +99,11 @@ const expressionVariables: ExpressionVariablesDictionaryType = {
   productAvailableQuantity: (seller: Seller, _logisticsInfo?: LogisticsInfo) =>
     seller.commertialOffer.AvailableQuantity,
   minShippingPrice: (_seller: Seller, logisticsInfo?: LogisticsInfo) =>
-    logisticsInfo?.slas[0]?.price
+    logisticsInfo?.slas[0]?.price !== undefined
       ? sortSLAByField.minPrice(logisticsInfo?.slas)[0]?.price / 100
       : undefined,
   maxShippingPrice: (_seller: Seller, logisticsInfo?: LogisticsInfo) =>
-    logisticsInfo?.slas[0]?.price
+    logisticsInfo?.slas[0]?.price !== undefined
       ? sortSLAByField.maxPrice(logisticsInfo?.slas)[0]?.price / 100
       : undefined,
   minShippingEstimate: (_seller: Seller, logisticsInfo?: LogisticsInfo) => {


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->
When the SLA price is $0.00, the sort did not consider this SLA, but it's wrong behavior. The sort needs to consider the SLA with price $0.00.

This PR fixes this problem and now it's working well.

**Thread about problem:** https://vtex.slack.com/archives/C01H63MUA21/p1659102925048629

#### How to test it?
<!--- Don't forget to add a link to a Workspace where this branch is linked -->

run `yarn test`

[Workspace](https://storetheme--lojaiwannasleep.myvtex.com/sabonete-liquido-iws-comfy-wish-250ml/p)

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/yoJC2GnSClbPOkV0eA/giphy.gif)
