### PR TITLE
fix logisticsInfo when get error

### DIFF
--- a/react/__tests__/hooks/useSellerLogisticsInfo.test.ts
+++ b/react/__tests__/hooks/useSellerLogisticsInfo.test.ts
@@ -100,4 +100,33 @@ describe('useNewProductWithSellers', () => {
       shippingData.shipping.logisticsInfo[1]
     )
   })
+
+  it('should return correctly when got error to find logistcInfo', async () => {
+    // arrange
+    jest
+      .spyOn(reactapollo, 'useLazyQuery')
+      .mockImplementation()
+      .mockReturnValue([
+        jest.fn(),
+        {
+          error: new Error(),
+          refetch: jest.fn(),
+        },
+      ] as any)
+
+    // act
+    const {
+      result: { current: sellersInfoResult },
+    } = renderHook(() => useSellerLogisticsInfo())
+
+    // assert
+    expect(sellersInfoResult[0].seller).toStrictEqual(
+      productContextState.selectedItem?.sellers[0]
+    )
+    expect(sellersInfoResult[0].logisticsInfo).toBeUndefined()
+    expect(sellersInfoResult[1].seller).toStrictEqual(
+      productContextState.selectedItem?.sellers[1]
+    )
+    expect(sellersInfoResult[1].logisticsInfo).toBeUndefined()
+  })
 })

--- a/react/hooks/useSellerLogisticsInfo.ts
+++ b/react/hooks/useSellerLogisticsInfo.ts
@@ -13,7 +13,7 @@ export const useSellerLogisticsInfo = (): SellerLogisticsInfoResult[] => {
   const { selectedItem, selectedQuantity } = useProduct() ?? {}
   const orderFormContext = OrderForm?.useOrderForm() ?? {}
 
-  const [updateShippingQuotes, { data: shippingData }] = useLazyQuery<{
+  const [updateShippingQuotes, { data: shippingData, error }] = useLazyQuery<{
     shipping: ShippingQuote
   }>(SimulateShippingQuery)
 
@@ -67,12 +67,23 @@ export const useSellerLogisticsInfo = (): SellerLogisticsInfoResult[] => {
     updateShippingQuotes({ variables: { ...variables } })
   }, [updateShippingQuotes, variables])
 
-  return availableSellers && logisticsInfo
-    ? availableSellers.map((seller, index) => {
-        return {
-          seller,
-          logisticsInfo: logisticsInfo[index],
-        }
-      })
-    : []
+  if (availableSellers && logisticsInfo) {
+    return availableSellers.map((seller, index) => {
+      return {
+        seller,
+        logisticsInfo: logisticsInfo[index],
+      }
+    })
+  }
+
+  if (availableSellers && error) {
+    return availableSellers.map((seller) => {
+      return {
+        seller,
+        logisticsInfo: undefined,
+      }
+    })
+  }
+
+  return []
 }


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->
When we have a problem getting `logisticsInfo` by graphql query, the PDP was infinite loading, because this behavior was not expected.
This PR fixes this problem and creates a better way to don't impact the load of PDP.

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/T7nRl5WHw7Yru/giphy.gif)
